### PR TITLE
ci: Rework CI to use repository dispatch. Add dependents workflow

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,36 @@
+name: Dependents
+on:
+  repository_dispatch:
+    types: [ publish-complete ]
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: version
+        run: |
+          VERSION=$(grep '"version":' package.json -m1 | cut -d\" -f4)
+          echo ::set-output name=version::${VERSION}
+
+  VisualPinball-Unity-Project-Hdrp:
+    runs-on: ubuntu-latest
+    needs: [ version ]
+    steps:
+      - name: Checkout VisualPinball.Unity.Project.Hdrp
+        uses: actions/checkout@v2
+        with:
+           repository: VisualPinball/VisualPinball.Unity.Project.Hdrp
+           token: ${{ secrets.GH_PAT }}
+      - name: Commit 
+        run: |
+          cd Packages
+          jq '.dependencies."org.visualpinball.engine.unity.hdrp" = "${{ needs.version.outputs.version }}"' manifest.json > manifest.json.tmp
+          mv manifest.json.tmp manifest.json
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git commit -m "chore(deps): Update org.visualpinball.engine.unity.hdrp to ${{ needs.version.outputs.version }}."
+          git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,49 +1,27 @@
-on: [push, pull_request]
+name: Publish
+on:
+  repository_dispatch:
+    types: [ release-complete ]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          lfs: true 
-      - name: Fetch next version
-        id: nextVersion
-        uses: VisualPinball/next-version-action@v0.1.6
-        with:
-          tagPrefix: 'v'
-      - name: Bump
-        if: ${{ steps.nextVersion.outputs.isBump == 'true' }} 
-        run: |
-          npm version ${{ steps.nextVersion.outputs.nextVersion }} --no-git-tag-version    
       - name: Publish
         run: |
           echo "//registry.visualpinball.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Commit
-        id: commit
-        if: ${{ steps.nextVersion.outputs.isBump == 'true' }} 
-        run: |
-          git config user.name "github-actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "release: ${{ steps.nextVersion.outputs.nextTag }}."
-          git push
-          commitish=$(git rev-parse HEAD)
-          echo ::set-output name=commitish::${commitish}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Release
-        uses: actions/create-release@v1
+
+  dispatch:
+    runs-on: ubuntu-latest
+    needs: [ publish ]
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
         with:
-          tag_name: ${{ steps.nextVersion.outputs.nextTag }}
-          release_name: ${{ steps.nextVersion.outputs.nextTag }}
-          prerelease: ${{ steps.nextVersion.outputs.isPrerelease }}
-          commitish: ${{ steps.commit.outputs.commitish }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
+          event-type: publish-complete
+          client-payload: '{"artifacts_run_id": "${{ github.run_id }}"}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+on: [push, pull_request] 
+ 
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true 
+      - name: Fetch next version
+        id: nextVersion
+        uses: VisualPinball/next-version-action@v0.1.7
+        with:
+          tagPrefix: 'v'
+      - name: Bump
+        if: ${{ steps.nextVersion.outputs.isBump == 'true' }} 
+        run: |
+          npm version ${{ steps.nextVersion.outputs.nextVersion }} --no-git-tag-version    
+      - name: Commit
+        id: commit
+        if: ${{ steps.nextVersion.outputs.isBump == 'true' }} 
+        run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "release: ${{ steps.nextVersion.outputs.nextTag }}."
+          git push
+          commitish=$(git rev-parse HEAD)
+          echo ::set-output name=commitish::${commitish}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.nextVersion.outputs.nextTag }}
+          release_name: ${{ steps.nextVersion.outputs.nextTag }}
+          prerelease: ${{ steps.nextVersion.outputs.isPrerelease }}
+          commitish: ${{ steps.commit.outputs.commitish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch:
+    runs-on: ubuntu-latest
+    needs: [ release ]
+    if: github.repository == 'VisualPinball/VisualPinball.Unity.Hdrp' && github.ref == 'refs/heads/master' && github.event_name == 'push'
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_PAT }}
+          event-type: release-complete
+          client-payload: '{"artifacts_run_id": "${{ github.run_id }}"}'

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "Unity",
     "HDRP"
   ],
-  "unity": "2020.2",
-  "unityRelease": "0f1",
+  "unity": "2020.3",
+  "unityRelease": "12f1",
   "dependencies": {
-    "com.unity.render-pipelines.high-definition": "10.2.2",
-    "com.unity.render-pipelines.high-definition-config": "10.2.2",
+    "com.unity.render-pipelines.high-definition": "10.5.0",
+    "com.unity.render-pipelines.high-definition-config": "10.5.0",
     "org.visualpinball.engine.unity": "0.0.1-preview.51",
     "org.visualpinball.unity.assetlibrary": "0.0.1-preview.16"
   },


### PR DESCRIPTION
This PR reworks the CI to use repository dispatches like we started to do for MPF and PinMAME projects.

It also automatically bumps the `VisualPinball/VisualPinball.Unity.Hdrp` project.