### PR TITLE
Update renderer to use emissive color methods

### DIFF
--- a/Runtime/MaterialConverter.cs
+++ b/Runtime/MaterialConverter.cs
@@ -53,6 +53,7 @@ namespace VisualPinball.Engine.Unity.Hdrp
 		private static readonly int DiffusionProfileAsset = Shader.PropertyToID("_DiffusionProfileAsset");
 		private static readonly int DiffusionProfileHash = Shader.PropertyToID("_DiffusionProfileHash");
 		private static readonly int MaterialID = Shader.PropertyToID("_MaterialID");
+		private static readonly int EmissiveColor = Shader.PropertyToID("_EmissiveColor");
 
 		#endregion
 
@@ -209,6 +210,16 @@ namespace VisualPinball.Engine.Unity.Hdrp
 		public void SetMaterialType(Material material, MaterialType materialType)
 		{
 			material.SetFloat(MaterialID, (int)materialType);
+		}
+
+		public void SetEmissiveColor(MaterialPropertyBlock propBlock, Color color)
+		{
+			propBlock.SetColor(EmissiveColor, color);
+		}
+
+		public Color? GetEmissiveColor(Material material)
+		{
+			return material.GetColor(EmissiveColor);
 		}
 
 		private static Vector4 ConvertGUIDToVector4(string guid)

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "Unity",
     "HDRP"
   ],
-  "unity": "2020.3",
-  "unityRelease": "12f1",
+  "unity": "2021.2",
+  "unityRelease": "7f1",
   "dependencies": {
-    "com.unity.render-pipelines.high-definition": "10.5.0",
-    "com.unity.render-pipelines.high-definition-config": "10.5.0",
-    "org.visualpinball.engine.unity": "0.0.1-preview.83",
+    "com.unity.render-pipelines.high-definition": "12.1.2",
+    "com.unity.render-pipelines.high-definition-config": "12.1.2",
+    "org.visualpinball.engine.unity": "0.0.1-preview.85",
     "org.visualpinball.unity.assetlibrary": "0.0.1-preview.51"
   },
   "author": "freezy <freezy@vpdb.io>",


### PR DESCRIPTION
This PR updates the renderer to implement the new emissive color methods added to the `IMaterialConverter` interface.

These methods were added so that we could support URP. Entering the player currently is crashing when a lamp is turned on or off.

Refer to https://github.com/freezy/VisualPinball.Engine/pull/367 for additional information.